### PR TITLE
Add Win11 22H2 support

### DIFF
--- a/ContextMenuNormalizer/ContextMenuNormalizer.cpp
+++ b/ContextMenuNormalizer/ContextMenuNormalizer.cpp
@@ -5,7 +5,7 @@
 #include <sysinfoapi.h>
 
 #include "ThemeEditor.h"
-#include "Win8RP.h"
+#include "PopupMenus.h"
 
 #pragma comment(lib, "user32.lib")
 #pragma comment(lib, "uxtheme.lib")
@@ -137,68 +137,6 @@ void Recolorize_Menu_PopupSeparator11(int* r, int* g, int* b, int* a) {
 }
 #pragma endregion
 
-static void prvReplace(int iXPos, int iYPos, int iSize, Pixel_t xBoarder, Pixel_t xFill, Pixel_t* pPixels) {
-    Pixel_t xBackground;
-    xBackground.bits.r = 249;
-    xBackground.bits.g = 249;
-    xBackground.bits.b = 249;
-    xBackground.bits.a = 255;
-    for (int iX = iXPos; iX < iXPos + iSize; iX++) {
-        for (int iY = iYPos; iY < iYPos + iSize; iY++) {
-            if (iX == iXPos || iY == iYPos || iX == iXPos + iSize-1 || iY == iYPos + iSize-1) {
-                vSetPixel(pPixels, iX, iY, iSize, xBoarder);
-            }
-            else {
-                vSetPixel(pPixels, iX, iY, iSize, xFill);
-            }
-        }
-    }
-    //vSetPixel(pPixels, 0, 0, iSize, xBoarder);
-}
-
-int qwq(int iWidth, int iHeight, Pixel_t* pPixels, void* pParam) {
-    Pixel_t xBoarder;
-    Pixel_t xFill;
-
-    xBoarder.bits.r = 249;
-    xBoarder.bits.g = 249;
-    xBoarder.bits.b = 249;
-    xBoarder.bits.a = 255;
-
-    xFill.bits.r = 249;
-    xFill.bits.g = 249;
-    xFill.bits.b = 249;
-    xFill.bits.a = 255;
-
-    //prvReplace(0, iWidth * 0, iWidth, xBoarder, xFill, pPixels);
-    //prvReplace(0, iWidth * 2, iWidth, xBoarder, xFill, pPixels);
-
-    xBoarder.bits.r = 127;
-    xBoarder.bits.g = 181;
-    xBoarder.bits.b = 236;
-    xBoarder.bits.a = 255;
-
-    xFill.bits.r = 222;
-    xFill.bits.g = 239;
-    xFill.bits.b = 255;
-    xFill.bits.a = 255;
-
-    prvReplace(0, iWidth * 1, iWidth, xBoarder, xFill, pPixels);
-
-    xBoarder.bits.r = 181;
-    xBoarder.bits.g = 236;
-    xBoarder.bits.b = 255;
-    xBoarder.bits.a = 127;
-
-    xFill.bits.r = 222;
-    xFill.bits.g = 0;
-    xFill.bits.b = 0;
-    xFill.bits.a = 255;
-    prvReplace(0, iWidth * 3, iWidth, xBoarder, xFill, pPixels);
-
-    return 1;
-}
-
 int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
     _In_opt_ HINSTANCE hPrevInstance,
     _In_ LPWSTR    lpCmdLine,
@@ -235,9 +173,9 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
     }
     else {
         // Win11 22H2 and after
-        ModifyContextMenuBitmap(L"Menu", 27, iWin8RP_PopupMenu, NULL);  // The new "MENU_POPUPITEM" in use
-        ModifyContextMenuBitmap(L"Menu", MENU_POPUPITEM, iWin8RP_PopupMenu, NULL);
-        ModifyContextMenuBitmap(L"ImmersiveStart::Menu", MENU_POPUPITEM, iWin8RP_PopupMenu, NULL);
+        ModifyContextMenuBitmap(L"Menu", 27, iWin11_21H1_PopupMenu, NULL);  // The new "MENU_POPUPITEM" in use
+        ModifyContextMenuBitmap(L"Menu", MENU_POPUPITEM, iWin11_21H1_PopupMenu, NULL);
+        ModifyContextMenuBitmap(L"ImmersiveStart::Menu", MENU_POPUPITEM, iWin11_21H1_PopupMenu, NULL);
     }
 
     return 0;

--- a/ContextMenuNormalizer/ContextMenuNormalizer.vcxproj
+++ b/ContextMenuNormalizer/ContextMenuNormalizer.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -140,6 +140,8 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="ContextMenuNormalizer.cpp" />
+    <ClCompile Include="ThemeEditor.cpp" />
+    <ClCompile Include="Win8RP.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Manifest Include="ContextMenuNormalizer.exe.manifest" />
@@ -149,6 +151,8 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h" />
+    <ClInclude Include="ThemeEditor.h" />
+    <ClInclude Include="Win8RP.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/ContextMenuNormalizer/ContextMenuNormalizer.vcxproj
+++ b/ContextMenuNormalizer/ContextMenuNormalizer.vcxproj
@@ -140,6 +140,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="ContextMenuNormalizer.cpp" />
+    <ClCompile Include="Win11_21H1.cpp" />
     <ClCompile Include="ThemeEditor.cpp" />
     <ClCompile Include="Win8RP.cpp" />
   </ItemGroup>
@@ -152,7 +153,7 @@
   <ItemGroup>
     <ClInclude Include="resource.h" />
     <ClInclude Include="ThemeEditor.h" />
-    <ClInclude Include="Win8RP.h" />
+    <ClInclude Include="PopupMenus.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/ContextMenuNormalizer/ContextMenuNormalizer.vcxproj.filters
+++ b/ContextMenuNormalizer/ContextMenuNormalizer.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClCompile Include="Win8RP.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Win11_21H1.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Manifest Include="ContextMenuNormalizer.exe.manifest">
@@ -42,7 +45,7 @@
     <ClInclude Include="ThemeEditor.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="Win8RP.h">
+    <ClInclude Include="PopupMenus.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/ContextMenuNormalizer/ContextMenuNormalizer.vcxproj.filters
+++ b/ContextMenuNormalizer/ContextMenuNormalizer.vcxproj.filters
@@ -18,6 +18,12 @@
     <ClCompile Include="ContextMenuNormalizer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ThemeEditor.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Win8RP.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Manifest Include="ContextMenuNormalizer.exe.manifest">
@@ -31,6 +37,12 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ThemeEditor.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Win8RP.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/ContextMenuNormalizer/PopupMenus.h
+++ b/ContextMenuNormalizer/PopupMenus.h
@@ -1,0 +1,9 @@
+#ifndef __INCLUDE_WIN8RP_H_
+#define __INCLUDE_WIN8RP_H_
+
+#include "ThemeEditor.h"
+
+int iWin8_RP_PopupMenu(int iWidth, int iHeight, Pixel_t* pPixels, void* pParam);
+int iWin11_21H1_PopupMenu(int iWidth, int iHeight, Pixel_t* pPixels, void* pParam);
+
+#endif // __INCLUDE_WIN8RP_H_

--- a/ContextMenuNormalizer/ThemeEditor.cpp
+++ b/ContextMenuNormalizer/ThemeEditor.cpp
@@ -1,0 +1,140 @@
+#include "ThemeEditor.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <Windows.h>
+#include <Uxtheme.h>
+#include <vsstyle.h>
+#include <vssym32.h>
+#include <sysinfoapi.h>
+
+#pragma comment(lib, "user32.lib")
+#pragma comment(lib, "uxtheme.lib")
+#pragma warning(disable : 4996)
+
+#if _DEBUG
+#include <iostream>
+#endif
+
+#pragma region Pixel Color
+
+static inline int PixClr(int val)
+{
+    return val & 0xFFFFFF;
+}
+
+static inline int PixR(BYTE* pPixel)
+{
+    return PixClr(pPixel[2]);
+}
+static inline int PixG(BYTE* pPixel)
+{
+    return PixClr(pPixel[1]);
+}
+static inline int PixB(BYTE* pPixel)
+{
+    return PixClr(pPixel[0]);
+}
+static inline int PixA(BYTE* pPixel)
+{
+    return PixClr(pPixel[3]);
+}
+
+#pragma endregion
+
+typedef struct {
+    PixelModifier pmPixelModifier;
+    BitmapHandler pmSimpleReplacer;
+} CallContext_t;
+
+static void prvSimpleWrapper(const RBContext_t* pxContext, Pixel_t* pPixel, void* pParam) {
+    CallContext_t* pCallContext = (CallContext_t*)pParam;
+    int r = pPixel->bits.r;
+    int g = pPixel->bits.g;
+    int b = pPixel->bits.b;
+    int a = pPixel->bits.a;
+    pCallContext->pmSimpleReplacer(&r, &g, &b, &a);
+    pPixel->bits.r = r;
+    pPixel->bits.g = g;
+    pPixel->bits.b = b;
+    pPixel->bits.a = a;
+}
+
+static int prvRecolorizeBitmap(int iWidth, int iHeight, Pixel_t *pPixels, void* pParam)
+{
+    RBContext_t xRBContext;
+    xRBContext.width = iWidth;
+    xRBContext.height = iHeight;
+
+    for (xRBContext.y = 0; xRBContext.y < iHeight; xRBContext.y++) {
+        Pixel_t* pPixel = pPixels + (iWidth * xRBContext.y);
+
+        for (xRBContext.x = 0; xRBContext.x < iWidth; xRBContext.x++) {
+#if _DEBUG
+            _RPT1(0, "(%d, %d, %d / %d) \n", pPixel->bits.r, pPixel->bits.g, pPixel->bits.b, pPixel->bits.a);
+#endif
+            CallContext_t* pCallContext = (CallContext_t*) pParam;
+            pCallContext->pmPixelModifier(&xRBContext, pPixel, pParam);
+
+            pPixel ++;
+        }
+    }
+
+    return TRUE;
+}
+
+int ModifyContextMenuBitmap(LPCWSTR pszClassList, int iPartId, BitmapModifier pmModifier, void* pParam)
+{
+    HBITMAP hBitmap;
+
+    HTHEME hTheme = OpenThemeData(GetForegroundWindow(), pszClassList);
+    GetThemeBitmap(hTheme, iPartId, 0, TMT_DIBDATA, GBF_DIRECT, &hBitmap);
+    CloseThemeData(hTheme);
+
+    BITMAP xBitMap;
+    GetObject(hBitmap, sizeof(xBitMap), &xBitMap);
+
+    if (!hBitmap || xBitMap.bmBitsPixel != 32) {
+        // Format is not ARGB
+        return FALSE;
+    }
+
+    int result = FALSE;
+    LONG xPixelCount = xBitMap.bmWidth * xBitMap.bmHeight;
+    LONG xBitCount = xPixelCount * sizeof(Pixel_t);
+    Pixel_t* pPixels = (Pixel_t*)malloc(xBitCount);
+    if (!pPixels) {
+        return result;
+    }
+
+    if (!GetBitmapBits(hBitmap, xBitCount, pPixels)) {
+        goto free_bits;
+    }
+
+    result = pmModifier(xBitMap.bmWidth, xBitMap.bmHeight, pPixels, pParam);
+
+    if (!SetBitmapBits(hBitmap, xBitCount, pPixels)) {
+        goto free_bits;
+    }
+
+free_bits:
+    if (pPixels) {
+        free(pPixels);
+    }
+
+    return result;
+}
+
+int NormalizeContextMenu(LPCWSTR pszClassList, int iPartId, BitmapHandler pmHandler) {
+    CallContext_t xContext;
+    xContext.pmPixelModifier = prvSimpleWrapper;
+    xContext.pmSimpleReplacer = pmHandler;
+    return ModifyContextMenuBitmap(pszClassList, iPartId, prvRecolorizeBitmap, &xContext);
+}
+
+int NormalizeContextMenuEx(LPCWSTR pszClassList, int iPartId, PixelModifier pmHandler) {
+    CallContext_t xContext;
+    xContext.pmPixelModifier = pmHandler;
+    return ModifyContextMenuBitmap(pszClassList, iPartId, prvRecolorizeBitmap, &xContext);
+}

--- a/ContextMenuNormalizer/ThemeEditor.h
+++ b/ContextMenuNormalizer/ThemeEditor.h
@@ -1,0 +1,34 @@
+#ifndef __INCLUDE_THEME_EDITOR_H_
+#define __INCLUDE_THEME_EDITOR_H_
+
+#include <stdint.h>
+
+#include <Windows.h>
+
+// MSB --- ARGB --> LSB
+typedef union {
+    uint32_t all;
+    struct {
+        uint8_t b, g, r, a;
+    } bits;
+} Pixel_t;
+
+typedef struct {
+    int x, y;
+    int width, height;
+} RBContext_t;
+
+static inline void vSetPixel(Pixel_t* pPixels, int iX, int iY, int iWidth, Pixel_t xPixel) {
+    pPixels[iWidth * iY + iX] = xPixel;
+}
+
+typedef void (*BitmapHandler)(int* r, int* g, int* b, int* a);
+typedef void (*PixelModifier)(const RBContext_t* pxContext, Pixel_t* pPixels, void* pParam);
+typedef int (*BitmapModifier)(int iWidth, int iHeight, Pixel_t* pPixels, void* pParam);
+
+Pixel_t xGetPixel(uint32_t uiRawPixel);
+
+int ModifyContextMenuBitmap(LPCWSTR pszClassList, int iPartId, BitmapModifier pmModifier, void* pParam);
+int NormalizeContextMenu(LPCWSTR pszClassList, int iPartId, BitmapHandler pmHandler);
+
+#endif // !__INCLUDE_THEME_EDITOR_H_

--- a/ContextMenuNormalizer/Win11_21H1.cpp
+++ b/ContextMenuNormalizer/Win11_21H1.cpp
@@ -1,0 +1,70 @@
+#include "PopupMenus.h"
+#include "ThemeEditor.h"
+
+Pixel_t apxCorner[4][4] = {
+    {0xFFF9F9F9, 0xFFCAE1F2, 0xFF449BDE, 0xFF057BD5},
+    {0xFFCAE1F2, 0xFF097DD6, 0xFF0078D4, 0xFF0078D4},
+    {0xFF449BDE, 0xFF0078D4, 0xFF0078D4, 0xFF0078D4},
+    {0xFF057BD5, 0xFF0078D4, 0xFF0078D4, 0xFF0078D4}
+};
+
+static void prvPaint(int iXPos, int iYPos, int iSize, Pixel_t* pPixels) {
+    // Top-Left
+    for (int iX = 0; iX < 4; iX++) {
+        for (int iY = 0; iY < 4; iY++) {
+            vSetPixel(pPixels, iXPos + iX, iYPos + iY, iSize, apxCorner[iX][iY]);
+        }
+    }
+
+    // Top-Right
+    for (int iX = 0; iX < 4; iX++) {
+        for (int iY = 0; iY < 4; iY++) {
+            vSetPixel(pPixels, iXPos + iSize - iX - 1, iYPos + iY, iSize, apxCorner[iX][iY]);
+        }
+    }
+
+    // Bottom-Left
+    for (int iX = 0; iX < 4; iX++) {
+        for (int iY = 0; iY < 4; iY++) {
+            vSetPixel(pPixels, iXPos + iX, iYPos + iSize - iY - 1, iSize, apxCorner[iX][iY]);
+        }
+    }
+
+    // Bottom-Right
+    for (int iX = 0; iX < 4; iX++) {
+        for (int iY = 0; iY < 4; iY++) {
+            vSetPixel(pPixels, iXPos + iSize - iX - 1, iYPos + iSize - iY - 1, iSize, apxCorner[iX][iY]);
+        }
+    }
+}
+
+static void prvFill(int iXPos, int iYPos, int iSize, Pixel_t xFill, Pixel_t* pPixels) {
+    for (int iX = iXPos; iX < iXPos + iSize; iX++) {
+        for (int iY = iYPos; iY < iYPos + iSize; iY++) {
+            vSetPixel(pPixels, iX, iY, iSize, xFill);
+        }
+    }
+}
+
+int iWin11_21H1_PopupMenu(int iWidth, int iHeight, Pixel_t* pPixels, void* pParam) {
+    Pixel_t xFill;
+
+    xFill.bits.r = 249;
+    xFill.bits.g = 249;
+    xFill.bits.b = 249;
+    xFill.bits.a = 255;
+
+    prvFill(0, iWidth * 0, iWidth, xFill, pPixels);
+    prvFill(0, iWidth * 2, iWidth, xFill, pPixels);
+    prvFill(0, iWidth * 3, iWidth, xFill, pPixels);
+
+    xFill.bits.r = 0;
+    xFill.bits.g = 120;
+    xFill.bits.b = 212;
+    xFill.bits.a = 255;
+
+    prvFill(0, iWidth * 1, iWidth, xFill, pPixels);
+    prvPaint(0, iWidth * 1, iWidth, pPixels);
+
+    return 1;
+}

--- a/ContextMenuNormalizer/Win8RP.cpp
+++ b/ContextMenuNormalizer/Win8RP.cpp
@@ -1,0 +1,58 @@
+#include "Win8RP.h"
+#include "ThemeEditor.h"
+
+static void prvReplace(int iXPos, int iYPos, int iSize, Pixel_t xBoarder, Pixel_t xFill, Pixel_t* pPixels) {
+    for (int iX = iXPos; iX < iXPos + iSize; iX++) {
+        for (int iY = iYPos; iY < iYPos + iSize; iY++) {
+            if (iX == iXPos || iY == iYPos || iX == iXPos + iSize - 1 || iY == iYPos + iSize - 1) {
+                vSetPixel(pPixels, iX, iY, iSize, xBoarder);
+            }
+            else {
+                vSetPixel(pPixels, iX, iY, iSize, xFill);
+            }
+        }
+    }
+}
+
+int iWin8RP_PopupMenu(int iWidth, int iHeight, Pixel_t* pPixels, void* pParam) {
+    Pixel_t xBoarder;
+    Pixel_t xFill;
+
+    xBoarder.bits.r = 249;
+    xBoarder.bits.g = 249;
+    xBoarder.bits.b = 249;
+    xBoarder.bits.a = 255;
+
+    xFill.bits.r = 249;
+    xFill.bits.g = 249;
+    xFill.bits.b = 249;
+    xFill.bits.a = 255;
+
+    prvReplace(0, iWidth * 0, iWidth, xBoarder, xFill, pPixels);
+    prvReplace(0, iWidth * 2, iWidth, xBoarder, xFill, pPixels);
+
+    xBoarder.bits.r = 127;
+    xBoarder.bits.g = 181;
+    xBoarder.bits.b = 236;
+    xBoarder.bits.a = 255;
+
+    xFill.bits.r = 222;
+    xFill.bits.g = 239;
+    xFill.bits.b = 255;
+    xFill.bits.a = 255;
+
+    prvReplace(0, iWidth * 1, iWidth, xBoarder, xFill, pPixels);
+
+    xBoarder.bits.r = 219;
+    xBoarder.bits.g = 219;
+    xBoarder.bits.b = 219;
+    xBoarder.bits.a = 255;
+
+    xFill.bits.r = 249;
+    xFill.bits.g = 249;
+    xFill.bits.b = 249;
+    xFill.bits.a = 255;
+    prvReplace(0, iWidth * 3, iWidth, xBoarder, xFill, pPixels);
+
+    return 1;
+}

--- a/ContextMenuNormalizer/Win8RP.cpp
+++ b/ContextMenuNormalizer/Win8RP.cpp
@@ -1,4 +1,4 @@
-#include "Win8RP.h"
+#include "PopupMenus.h"
 #include "ThemeEditor.h"
 
 static void prvReplace(int iXPos, int iYPos, int iSize, Pixel_t xBoarder, Pixel_t xFill, Pixel_t* pPixels) {
@@ -14,7 +14,7 @@ static void prvReplace(int iXPos, int iYPos, int iSize, Pixel_t xBoarder, Pixel_
     }
 }
 
-int iWin8RP_PopupMenu(int iWidth, int iHeight, Pixel_t* pPixels, void* pParam) {
+int iWin8_RP_PopupMenu(int iWidth, int iHeight, Pixel_t* pPixels, void* pParam) {
     Pixel_t xBoarder;
     Pixel_t xFill;
 

--- a/ContextMenuNormalizer/Win8RP.h
+++ b/ContextMenuNormalizer/Win8RP.h
@@ -1,8 +1,0 @@
-#ifndef __INCLUDE_WIN8RP_H_
-#define __INCLUDE_WIN8RP_H_
-
-#include "ThemeEditor.h"
-
-int iWin8RP_PopupMenu(int iWidth, int iHeight, Pixel_t* pPixels, void* pParam);
-
-#endif // __INCLUDE_WIN8RP_H_

--- a/ContextMenuNormalizer/Win8RP.h
+++ b/ContextMenuNormalizer/Win8RP.h
@@ -1,0 +1,8 @@
+#ifndef __INCLUDE_WIN8RP_H_
+#define __INCLUDE_WIN8RP_H_
+
+#include "ThemeEditor.h"
+
+int iWin8RP_PopupMenu(int iWidth, int iHeight, Pixel_t* pPixels, void* pParam);
+
+#endif // __INCLUDE_WIN8RP_H_


### PR DESCRIPTION
Add support for Win11 22H2, increase the contrast of the context menu:
![image](https://user-images.githubusercontent.com/4704366/204297711-0b0b74c0-e0a8-4622-892f-f14e8d22d6c1.png)

Also applies to the classic menu:
![image](https://user-images.githubusercontent.com/4704366/204297868-8d95f0b4-e0c2-4cb1-aaa8-fdb0077fb10d.png)

Plus some code clean up